### PR TITLE
fix use under debugger

### DIFF
--- a/lib/B/Hooks/AtRuntime.xs
+++ b/lib/B/Hooks/AtRuntime.xs
@@ -37,12 +37,13 @@ count_BEGINs ()
     PREINIT:
         I32 c = 0;
         const PERL_CONTEXT *cx;
+        const PERL_CONTEXT *dbcx;
         const CV *cxcv;
     CODE:
         RETVAL = 0;
-        while ((cx = caller_cx(c++, NULL))) {
-            if (CxTYPE(cx) == CXt_SUB   &&
-                (cxcv = cx->blk_sub.cv) &&
+        while ((cx = caller_cx(c++, &dbcx))) {
+            if (CxTYPE(dbcx) == CXt_SUB   &&
+                (cxcv = dbcx->blk_sub.cv) &&
                 CvSPECIAL(cxcv)         &&
                 strEQ(GvNAME(CvGV(cxcv)), "BEGIN")
             )
@@ -56,17 +57,18 @@ compiling_string_eval ()
     PREINIT:
         I32 c = 0;
         const PERL_CONTEXT *cx;
+        const PERL_CONTEXT *dbcx;
         const CV *cxcv;
     CODE:
         RETVAL = 0;
-        while ((cx = caller_cx(c++, NULL))) {
-            if (CxTYPE(cx) == CXt_SUB   &&
-                (cxcv = cx->blk_sub.cv) &&
+        while ((cx = caller_cx(c++, &dbcx))) {
+            if (CxTYPE(dbcx) == CXt_SUB   &&
+                (cxcv = dbcx->blk_sub.cv) &&
                 CvSPECIAL(cxcv)         &&
                 strEQ(GvNAME(CvGV(cxcv)), "BEGIN")
             ) {
-                cx = caller_cx(c + 1, NULL);
-                if (cx && CxREALEVAL(cx))
+                cx = caller_cx(c + 1, &dbcx);
+                if (cx && CxREALEVAL(dbcx))
                     RETVAL = 1;
                 break;
             }


### PR DESCRIPTION
When running under the debugger, caller_cx will return information about
the call to DB::sub, because it has information about the call being
made. To get information about the thing being called, you need to use
the second parameter to caller_cx which will get a separate context
structure.